### PR TITLE
MoE offloading and code simplification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ safetensors
 diffusers
 transformers
 accelerate
+cachetools

--- a/segmoe/main.py
+++ b/segmoe/main.py
@@ -196,7 +196,7 @@ class SegMoEPipeline:
                     "Base class not yet supported, type should be one of ['sd','sdxl]"
                 )
             if self.offload_layer != -1:
-                unet.to = move(unet, "cpu")  # type: ignore
+                unet.to = move(unet, "cpu", self.move_fn)  # type: ignore
             self.pipe = self.base_cls.from_pretrained(
                 cached_folder,
                 unet=unet,

--- a/segmoe/main.py
+++ b/segmoe/main.py
@@ -322,7 +322,7 @@ class SegMoEPipeline:
                 ):
                     try:
                         self.download_url(
-                            f"expert_{i}/model.safetensors", self.config["base_model"]
+                            f"expert_{i}/model.safetensors", exp["source_model"]
                         )
                         exp["source_model"] = f"expert_{i}/model.safetensors"
                         expert = self.base_cls.from_single_file(
@@ -374,7 +374,7 @@ class SegMoEPipeline:
                             try:
                                 self.download_url(
                                     f"expert_{i}/lora_{i}/pytorch_lora_weights.safetensors",
-                                    self.config["base_model"],
+                                    lora["source_model"],
                                 )
                                 lora["source_model"] = f"expert_{j}/lora_{j}"
                                 expert.load_lora_weights(lora["source_model"])
@@ -401,7 +401,7 @@ class SegMoEPipeline:
                         try:
                             self.download_url(
                                 f"lora_{i}/pytorch_lora_weights.safetensors",
-                                self.config["base_model"],
+                                lora["source_model"],
                             )
                             lora["source_model"] = f"lora_{i}"
                             self.pipe.load_lora_weights(lora["source_model"])
@@ -435,7 +435,7 @@ class SegMoEPipeline:
                         try:
                             self.download_url(
                                 f"lora_{i}/pytorch_lora_weights.safetensors",
-                                self.config["base_model"],
+                                lora["source_model"],
                             )
                             lora["source_model"] = f"lora_{i}"
                             experts[j[i]].load_lora_weights(lora["source_model"])

--- a/segmoe/main.py
+++ b/segmoe/main.py
@@ -131,7 +131,7 @@ class SegMoEPipeline:
         config_or_path: Path to Config or Directory containing SegMoE checkpoint or HF Card of SegMoE Checkpoint.
 
         Other Keyword Arguments:
-        torch_dtype: Data Type to load the pipeline in. (Default: torch.bfloat16)
+        torch_dtype: Data Type to load the pipeline in. (Default: torch.float16)
         variant: Variant of the Model. (Default: fp16)
         device: Device to load the model on. (Default: cuda)
         on_device_layers: How many layers to keep on device, '-1' for all layers. (Default: -1)
@@ -139,7 +139,7 @@ class SegMoEPipeline:
 
         For more details visit https://github.com/segmind/segmoe.
         """
-        self.torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)  # use bf16 instead of fp16 for increased base precision
+        self.torch_dtype = kwargs.pop("torch_dtype", torch.float16)
         self.use_safetensors = kwargs.pop("use_safetensors", True)
         self.variant = kwargs.pop("variant", "fp16")
         self.offload_layer = kwargs.pop("on_device_layers", -1)

--- a/segmoe/main.py
+++ b/segmoe/main.py
@@ -229,6 +229,7 @@ class SegMoEPipeline:
                 dtype=self.torch_dtype,
                 memory_format=torch.channels_last,
             )
+        torch.cuda.empty_cache()
 
     @classmethod
     def download_url(cls, file: str, url: str) -> None:
@@ -667,7 +668,9 @@ class SegMoEPipeline:
 
         Calls diffusers.DiffusionPipeline forward with the keyword arguments. See https://github.com/segmind/segmoe#usage for detailed usage.
         """
-        return self.pipe(*args, **kwargs)  # type: ignore
+        output = self.pipe(*args, **kwargs)  # type: ignore
+        torch.cuda.empty_cache()
+        return output
 
     def create_empty(self, path):
         with open(f"{path}/unet/config.json", "r") as f:
@@ -865,5 +868,5 @@ class SegMoEPipeline:
                 gate_vects[h], dim=0
             )  # (num_expert, num_layer, hidden_size)
             gate_vects[h].permute(1, 0)
-
+        torch.cuda.empty_cache()
         return gate_vects

--- a/segmoe/main.py
+++ b/segmoe/main.py
@@ -33,16 +33,16 @@ class EvictingLRUCache(LRUCache):
 
 
 def move(modul, moe_device):
-    def move_to_device(device: torch.device, dtype: torch.dtype = torch.bfloat16, memory_format: torch.memory_format = torch.channels_last):
-        def _move(module, moe: torch.device, device: torch.device, dtype: torch.dtype = torch.bfloat16, memory_format: torch.memory_format = torch.channels_last):
+    def move_to_device(device: torch.device, *args, **kwargs):
+        def _move(module, moe: torch.device, device: torch.device, *args, **kwargs):
             if isinstance(module, SparseMoeBlock):
-                module.to(device=moe, dtype=dtype, memory_format=memory_format)  # type: ignore
+                module.to(device=moe, *args, **kwargs)  # type: ignore
             else:
-                module.to(device=device, dtype=dtype, memory_format=memory_format)
+                module.to(device=device, **kwargs)
                 for child in module.children():
-                    _move(child, moe, device, dtype, memory_format)
+                    _move(child, moe, device, *args, **kwargs)
         for child in modul.children():
-            _move(child, moe_device, device, dtype, memory_format)
+            _move(child, moe_device, device, *args, **kwargs)
     return move_to_device
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
 setup(name='segmoe',
-      version='0.0.4',
+      version='0.0.5',
       description='Package for Mixing Stable Diffusiion XL Models by Segmind',
       url='https://github.com/segmind/segmoe',
       author='Yatharth Gupta',
@@ -21,7 +21,8 @@ setup(name='segmoe',
           'safetensors',
           'diffusers',
           'transformers',
-          'accelerate'
+          'accelerate',
+          'cachetools',
       ],
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
Make model creation a bit more readable and implement an LRU cache-based offload for MoE layers, which makes 4x2 SDXL models able to run on 12gb vram.

Example usage:
```python
from segmoe import SegMoEPipeline as seg
import torch

pipe = seg("SegMoE-4x2-v0", on_device_layers=800)
torch.cuda.empty_cache()  # make sure to clear cache before to experience vram savings
pipe("1girl, hatsune miku, beach, smiling").images[0].save("test.png")
```